### PR TITLE
allow explicitely disabling hubproxy for request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# temp files
+**swp
+**pyc
+**~

--- a/scrapylib/hubproxy.py
+++ b/scrapylib/hubproxy.py
@@ -41,7 +41,7 @@ class HubProxyMiddleware(object):
         return basic_auth_header(self.user, getattr(self, 'pass'))
 
     def process_request(self, request, spider):
-        if self.enabled:
+        if self.enabled and 'dont_proxy' not in request.meta:
             request.meta['proxy'] = self.url
             request.meta['download_timeout'] = self.download_timeout
             request.headers['Proxy-Authorization'] = self._proxyauth

--- a/scrapylib/tests/test_hubproxy.py
+++ b/scrapylib/tests/test_hubproxy.py
@@ -57,6 +57,16 @@ class HubProxyMiddlewareTestCase(TestCase):
         res = Response(req.url)
         assert mw.process_response(req, res, spider) is res
 
+        # disabled if 'dont_proxy' is set
+        req = Request('http://www.scrapytest.org')
+        req.meta['dont_proxy'] = True
+        assert mw.process_request(req, spider) is None
+        self.assertEqual(req.meta.get('proxy'), None)
+        self.assertEqual(req.meta.get('download_timeout'), None)
+        self.assertEqual(req.headers.get('Proxy-Authorization'), None)
+        res = Response(req.url)
+        assert mw.process_response(req, res, spider) is res
+
         if maxbans > 0:
             # assert ban count is reseted after a succesful response
             res = Response('http://ban.me', status=bancode)


### PR DESCRIPTION
This allows setting 'disable_proxy' in request.meta to disable hubproxy only for that specific request.
