### PR TITLE
Make HcfMiddleware._start_job method return job id and make it public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 scrapylib\.egg-info
 build/
 dist/
+.idea/
+.tox/

--- a/scrapylib/hcf.py
+++ b/scrapylib/hcf.py
@@ -114,12 +114,15 @@ class HcfMiddleware(object):
     def _msg(self, msg, level=log.INFO):
         log.msg('(HCF) %s' % msg, level)
 
-    def _start_job(self, spider):
+    def start_job(self, spider):
         self._msg("Starting new job for: %s" % spider.name)
-        jobid = self.panel_project.schedule(spider.name,
-                                               hs_consume_from_slot=self.hs_consume_from_slot,
-                                               dummy=datetime.now())
+        jobid = self.panel_project.schedule(
+            spider.name,
+            hs_consume_from_slot=self.hs_consume_from_slot,
+            dummy=datetime.now()
+        )
         self._msg("New job started: %s" % jobid)
+        return jobid
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -192,7 +195,7 @@ class HcfMiddleware(object):
             # Start the new job if this job had requests from the HCF or it
             # was the first job.
             if self.has_new_requests or not getattr(spider, 'dummy', None):
-                self._start_job(spider)
+                self.start_job(spider)
 
     def _get_new_requests(self):
         """ Get a new batch of links from the HCF."""


### PR DESCRIPTION
Motivation is to make new job ID available when overriding start_job method. This is useful if, for example, you want to add some tags to newly created job.

Unfortunately I failed to run tests locally and as a result  - write test for this change. It seems like I should have service for testing running in background (hubstorage mock?):

```
ConnectionError: HTTPConnectionPool(host='localhost', port=8003): Max retries exceeded with url: /hcf/2222222/test/s/0 (Caused by <class 'socket.error'>: [Errno 111] Connection refused)
```

If you explain me how can I run tests locally - I could write one and add to this PR.
