### PR TITLE
added: Option for number of retries for `HcfMiddleware`

### DIFF
--- a/scrapylib/hcf.py
+++ b/scrapylib/hcf.py
@@ -29,6 +29,9 @@ The next optional settings can be defined:
 
     HS_MAX_LINKS - Number of links to be read from the HCF, the default is 1000.
 
+    HS_MAX_RETRIES - Number of retries to be performed to the hubstorage
+                     server. The default is 8.
+
     HS_START_JOB_ENABLED - Enable whether to start a new job when the spider
                            finishes. The default is False
 
@@ -73,6 +76,7 @@ from scrapy.http import Request
 from hubstorage import HubstorageClient
 
 DEFAULT_MAX_LINKS = 1000
+DEFAULT_MAX_RETRIES = 8
 DEFAULT_HS_NUMBER_OF_SLOTS = 8
 
 
@@ -87,13 +91,14 @@ class HcfMiddleware(object):
         self.hs_consume_from_slot = self._get_config(settings, "HS_CONSUME_FROM_SLOT")
         self.hs_number_of_slots = settings.getint("HS_NUMBER_OF_SLOTS", DEFAULT_HS_NUMBER_OF_SLOTS)
         self.hs_max_links = settings.getint("HS_MAX_LINKS", DEFAULT_MAX_LINKS)
+        self.hs_max_retries = settings.getint("HS_MAX_RETRIES", DEFAULT_MAX_RETRIES)
         self.hs_start_job_enabled = settings.getbool("HS_START_JOB_ENABLED", False)
         self.hs_start_job_on_reason = settings.getlist("HS_START_JOB_ON_REASON", ['finished'])
 
         conn = Connection(self.hs_auth)
         self.panel_project = conn[self.hs_projectid]
 
-        self.hsclient = HubstorageClient(auth=self.hs_auth, endpoint=self.hs_endpoint)
+        self.hsclient = HubstorageClient(auth=self.hs_auth, endpoint=self.hs_endpoint, max_retries=self.hs_max_retries)
         self.project = self.hsclient.get_project(self.hs_projectid)
         self.fclient = self.project.frontier
 


### PR DESCRIPTION
Sometimes it's observed that requests in the upstream `python-hubstorage` package may fail, e.g:
```
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1169, in run
	    self.mainLoop()
	  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1178, in mainLoop
	    self.runUntilCurrent()
	  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 800, in runUntilCurrent
	    call.func(*call.args, **call.kw)
	  File "/usr/lib/pymodules/python2.7/scrapy/utils/reactor.py", line 41, in __call__
	    return self._func(*self._a, **self._kw)
	--- <exception caught here> ---
	  File "/usr/lib/pymodules/python2.7/scrapy/core/engine.py", line 106, in _next_request
	    request = next(slot.start_requests)
	  File "/tmp/eggs-3lbV9T/__main__.egg/radius/middlewares/hcf.py", line 147, in process_start_requests
	    
	  File "/tmp/eggs-3lbV9T/__main__.egg/radius/middlewares/hcf.py", line 220, in _get_new_requests
	    
	  File "/usr/lib/python2.7/dist-packages/hubstorage/frontier.py", line 60, in read
	    return self.apiget((frontier, 's', slot, 'q'), params=params)
	  File "/usr/lib/python2.7/dist-packages/hubstorage/resourcetype.py", line 40, in apiget
	    return self.apirequest(_path, method='GET', **kwargs)
	  File "/usr/lib/python2.7/dist-packages/hubstorage/resourcetype.py", line 34, in apirequest
	    return jldecode(self._iter_lines(_path, **kwargs))
	  File "/usr/lib/python2.7/dist-packages/hubstorage/resourcetype.py", line 27, in _iter_lines
	    r = self.client.session.request(**kwargs)
	  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 461, in request
	    resp = self.send(prep, **send_kwargs)
	  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 610, in send
	    r.content
	  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 730, in content
	    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
	  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 662, in generate
	    raise ConnectionError(e)
	requests.exceptions.ConnectionError: HTTPConnectionPool(host='storage.scrapinghub.com', port=80): Read timed out.
```
Simply retry that job and things may be fine.

The `HubstorageClient` class is configurable with an optional argument `max_retries`. Thus I think it may be a good idea to add a new option `HS_MAX_RETRIES`