### PR TITLE
Added deprecation note for CrawleraMiddleware

### DIFF
--- a/scrapylib/crawlera.py
+++ b/scrapylib/crawlera.py
@@ -28,6 +28,10 @@ class CrawleraMiddleware(object):
     ]
 
     def __init__(self, crawler):
+        warnings.warn(
+            'This version of CrawleraMiddleware is deprecated, '
+            'please use the version found in the scrapy-crawlera '
+            'package instead.')
         self.crawler = crawler
         self.job_id = os.environ.get('SCRAPY_JOB')
         self._bans = defaultdict(int)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='scrapylib',
-    version='1.5.0',
+    version='1.5.1',
     license='BSD',
     description='Scrapy helper functions and processors',
     author='Scrapinghub',


### PR DESCRIPTION
Added deprecation warning to CrawleraMiddleware as it's been moved to the [scrapy-crawlera](http://github.com/scrapinghub/scrapy-crawlera) package.