### PR TITLE
Fix new scrapy version cleanup

### DIFF
--- a/scrapylib/processors/__init__.py
+++ b/scrapylib/processors/__init__.py
@@ -4,13 +4,14 @@ import re
 import time
 from urlparse import urljoin
 
-from scrapy import log
-from scrapy.contrib.loader.processor import Compose, MapCompose, TakeFirst
+from scrapy.loader.processors import MapCompose, TakeFirst
 from scrapy.utils.markup import (remove_tags, replace_escape_chars,
                                  unquote_markup)
 
 
 _clean_spaces_re = re.compile("\s+", re.U)
+
+
 def clean_spaces(value):
     return _clean_spaces_re.sub(' ', value)
 

--- a/scrapylib/processors/date.py
+++ b/scrapylib/processors/date.py
@@ -1,5 +1,5 @@
 from dateutil.parser import parse
-from scrapy.contrib.loader.processor import Compose
+from scrapy.loader.processors import Compose
 from scrapy import log
 from scrapylib.processors import default_output_processor
 


### PR DESCRIPTION
This PR:

* resolves deprecation warnings with Scrapy 1.0.0
* does some code cleanup based on PEP8 (adds empty lines, removes unused imports)